### PR TITLE
ACC-1169 update to node12, rename master to main, update n-gage #14

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     [
       "env",
       {
-      	"targets": { "node": "8.10" }
+      	"targets": { "node": "12.x" }
 	  }
     ]
   ],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@financial-times/n-express-monitor": "^1.1.0"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^2.0.4",
+    "@financial-times/n-gage": "^8.2.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.5",
     "babel-loader": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "webpack-node-externals": "^1.7.2"
   },
   "engines": {
-    "node": ">=6.1.0"
+    "node": "12.x"
   }
 }


### PR DESCRIPTION
node 8 updated to node 12
n-gage version bumped up to 8.2.0 in package.json
rename `master` to `main` in circle ci file
closes #92 

**We're bumping how many n-gage versions?!**
TOO MANY. But I think none of those changes affect this repo.
v8.0.0 - the package-lock.json change is opt in https://github.com/Financial-Times/n-gage/releases/tag/v8.0.0
v7.0.0 - is an upgrade to Node v12 https://github.com/Financial-Times/n-gage/releases/tag/v7.0.0
v6.0.0 - something to do with asset-hashes.json, action only needed if this file is present in the project
v5.0.0 - updates Husky format. Staging smoke tests now run on https
v4.0.0 - removes all n-ui related code